### PR TITLE
add directions navigation using keyboard in the editor

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8,7 +8,9 @@ use ratatui::{
 
 use crate::app_state::{AppState};
 
-pub fn render_editor(frame: &mut Frame, area: Rect, app_state: &AppState) {
+pub fn render_editor(frame: &mut Frame, area: Rect, app_state: &mut AppState) {
+    app_state.ui_state.set_editor_offset(area.x, area.y);
+
     let lines_number = app_state.file_content.lines().count();
     let text: Vec<Line> = app_state.file_content
         .lines()


### PR DESCRIPTION
## Description

Add directions navigation using keyboard in the editor. Just basic arrows keys, nothing else right now.

It is also a bit faulty as it doesn't account for the lines numbers offset, but I think this needs a bit bigger refactoring to save lines and lines number offset as well, so we don't iterate over the lines on each render. It also should allow to insert characters into individual strings.