### PR TITLE
add cursor and text editing tests

### DIFF
--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -23,14 +23,14 @@ pub(super) fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app_sta
                             return Ok(());
                         }
 
-                        app_state.insert_character(character);
+                        app_state.ui_state.insert_character(character);
                     }
                     KeyCode::Left => app_state.ui_state.cursor_move_left(),
                     KeyCode::Right => app_state.ui_state.cursor_move_right(),
                     KeyCode::Down => app_state.ui_state.cursor_move_down(),
                     KeyCode::Up => app_state.ui_state.cursor_move_up(),
-                    KeyCode::Backspace => app_state.remove_previous_character(),
-                    KeyCode::Delete => app_state.remove_next_character(),
+                    KeyCode::Backspace => app_state.ui_state.remove_previous_character(),
+                    KeyCode::Delete => app_state.ui_state.remove_next_character(),
                     _ => {}
                 }
             }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,7 @@
 mod app;
 mod ui;
 mod text_editing;
+mod navigation;
 
 pub use app::AppState;
 pub use ui::FileTreeEntry;

--- a/src/app_state/app.rs
+++ b/src/app_state/app.rs
@@ -10,7 +10,6 @@ pub struct AppState {
     /// based on the provided path
     pub working_directory: PathBuf,
     pub file_tree: HashMap<PathBuf, Vec<FileTreeEntry>>,
-    pub lines: Vec<Vec<char>>,
     pub ui_state: UIState,
 }
 
@@ -22,9 +21,8 @@ impl AppState {
         AppState {
             working_directory,
             file_tree: HashMap::new(),
-            lines,
             // this is extremely safe, it needs to have 65535 digits to overflow
-            ui_state: UIState::new(lines_number.to_string().len() as u16)
+            ui_state: UIState::new(lines_number.to_string().len() as u16, lines)
         }
     }
 

--- a/src/app_state/navigation.rs
+++ b/src/app_state/navigation.rs
@@ -1,0 +1,85 @@
+use super::ui::UIState;
+
+impl UIState {
+    pub fn cursor_move_left(&mut self) {
+        if self.should_show_cursor && self.cursor_column > 1 {
+            let new_value = self.cursor_column - 1;
+            self.cursor_column = new_value;
+        }
+    }
+
+    pub fn cursor_move_right(&mut self) {
+        if self.should_show_cursor {
+            self.cursor_column = self.cursor_column + 1;
+        }
+    }
+
+    pub fn cursor_move_up(&mut self) {
+        if self.should_show_cursor && self.cursor_line > 1 {
+            let new_value = self.cursor_line - 1;
+            self.cursor_line = new_value;
+        }
+    }
+
+    pub fn cursor_move_down(&mut self) {
+        if self.should_show_cursor {
+            self.cursor_line = self.cursor_line + 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cannot_move_negative() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        ui_state.cursor_move_left();
+        ui_state.cursor_move_left();
+        ui_state.cursor_move_left();
+        
+        ui_state.cursor_move_up();
+        ui_state.cursor_move_up();
+        ui_state.cursor_move_up();
+
+        assert_eq!(ui_state.cursor_column, 1);
+        assert_eq!(ui_state.cursor_line, 1);
+    }
+
+    #[test]
+    fn moves_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        ui_state.cursor_move_right();
+        ui_state.cursor_move_right();
+
+        assert_eq!(ui_state.cursor_column, 3);
+
+        ui_state.cursor_move_left();
+
+        assert_eq!(ui_state.cursor_column, 2);
+
+        ui_state.cursor_move_down();
+        ui_state.cursor_move_down();
+
+        assert_eq!(ui_state.cursor_line, 3);
+
+        ui_state.cursor_move_up();
+
+        assert_eq!(ui_state.cursor_line, 2);
+    }
+}

--- a/src/app_state/text_editing.rs
+++ b/src/app_state/text_editing.rs
@@ -1,15 +1,15 @@
-use super::app::AppState;
+use super::ui::UIState;
 
-impl AppState {
+impl UIState {
     pub fn insert_character(&mut self, character: char) {
-        let result = self.lines.get_mut((self.ui_state.cursor_line - 1) as usize);
+        let result = self.lines.get_mut((self.cursor_line - 1) as usize);
 
         match result {
             Some(line) => {
-                let index = (self.ui_state.cursor_column - 1) as usize;
+                let index = (self.cursor_column - 1) as usize;
                 if index <= line.len() {
                     line.insert(index, character);
-                    self.ui_state.cursor_move_right();
+                    self.cursor_move_right();
                 }
             }
             None => {
@@ -19,9 +19,9 @@ impl AppState {
     }
 
     pub fn remove_previous_character(&mut self) {
-        let index = (self.ui_state.cursor_column - 1) as usize;
+        let index = (self.cursor_column - 1) as usize;
 
-        let result = self.lines.get_mut((self.ui_state.cursor_line - 1) as usize);
+        let result = self.lines.get_mut((self.cursor_line - 1) as usize);
 
         match result {
             Some(line) => {
@@ -30,7 +30,7 @@ impl AppState {
                     return;
                 } else if index <= line.len() {
                     line.remove(index - 1);
-                    self.ui_state.cursor_move_left();
+                    self.cursor_move_left();
                 }
             }
             None => {
@@ -41,9 +41,9 @@ impl AppState {
 
     // if `delete` is pressed, we delete the next character
     pub fn remove_next_character(&mut self) {
-        let index = (self.ui_state.cursor_column - 1) as usize;
+        let index = (self.cursor_column - 1) as usize;
 
-        let result = self.lines.get_mut((self.ui_state.cursor_line - 1) as usize);
+        let result = self.lines.get_mut((self.cursor_line - 1) as usize);
 
         match result {
             Some(line) => {
@@ -58,5 +58,72 @@ impl AppState {
                 // ????
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inserts_new_character_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        for _ in 0..6 {
+            ui_state.cursor_move_right();
+        }
+
+        ui_state.insert_character('m');
+        ui_state.insert_character('y');
+        ui_state.insert_character(' ');
+
+        assert_eq!(String::from_iter(&ui_state.lines[0]), "Hello my world!")
+    }
+
+    #[test]
+    fn deletes_previous_character_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        for _ in 0..6 {
+            ui_state.cursor_move_right();
+        }
+
+        // intentionally delete more than 6 characters
+        for _ in 0..15 {
+            ui_state.remove_previous_character();
+        }
+
+        assert_eq!(String::from_iter(&ui_state.lines[0]), "world!");
+        assert_eq!(ui_state.cursor_column, 1);
+    }
+
+    #[test]
+    fn deletes_next_character_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        for _ in 0..6 {
+            ui_state.remove_next_character();
+        }
+
+        assert_eq!(String::from_iter(&ui_state.lines[0]), "world!");
+        assert_eq!(ui_state.cursor_column, 1);
     }
 }

--- a/src/app_state/ui.rs
+++ b/src/app_state/ui.rs
@@ -33,17 +33,19 @@ impl FileTreeEntry {
 pub struct UIState {
     pub cursor_line: u16,
     pub cursor_column: u16,
+    pub lines: Vec<Vec<char>>,
     editor_offset_x: u16,
     editor_offset_y: u16,
-    should_show_cursor: bool,
+    pub(super) should_show_cursor: bool,
     prefix_len: u16,
 }
 
 impl UIState {
-    pub fn new(prefix_len: u16) -> Self {
+    pub fn new(prefix_len: u16, lines: Vec<Vec<char>>,) -> Self {
         UIState {
             cursor_line: 1,
             cursor_column: 1,
+            lines,
             editor_offset_x: 0,
             editor_offset_y: 0,
             should_show_cursor: false,
@@ -81,32 +83,6 @@ impl UIState {
                     // TODO: handle somehow
                 }
             }
-        }
-    }
-
-    pub fn cursor_move_left(&mut self) {
-        if self.should_show_cursor && self.cursor_column > 1 {
-            let new_value = self.cursor_column - 1;
-            self.cursor_column = new_value;
-        }
-    }
-
-    pub fn cursor_move_right(&mut self) {
-        if self.should_show_cursor {
-            self.cursor_column = self.cursor_column + 1;
-        }
-    }
-
-    pub fn cursor_move_up(&mut self) {
-        if self.should_show_cursor && self.cursor_line > 1 {
-            let new_value = self.cursor_line - 1;
-            self.cursor_line = new_value;
-        }
-    }
-
-    pub fn cursor_move_down(&mut self) {
-        if self.should_show_cursor {
-            self.cursor_line = self.cursor_line + 1;
         }
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11,8 +11,8 @@ use crate::app_state::{AppState};
 pub fn render_editor(frame: &mut Frame, area: Rect, app_state: &mut AppState) {
     app_state.ui_state.set_editor_offset(area.x, area.y);
 
-    let lines_number = app_state.lines.len();
-    let text: Vec<Line> = app_state.lines
+    let lines_number = app_state.ui_state.lines.len();
+    let text: Vec<Line> = app_state.ui_state.lines
         .iter()
         .enumerate()
         .map(|(i, line)| generate_code_line(line.iter().collect::<String>(), i, lines_number))


### PR DESCRIPTION
## Description

Refactor `lines` to be a part of the UI state. I think app state will be used to store:

- focused app part
- which UI components are open/closed (config will store the default values)
- which editor is currently active
- list of all open editors

So it makes sense to keep `lines` in the UI state (I think I should rename it to the editor state).

I also added tests to the existing functionality -- imo it will be 100% easier to develop it purely from a TDD perspective since the spec is quite clear, but testing it is exhaustive (and super easy to introduce regressions).

## Reference

Closes https://github.com/Bloomca/love/issues/28. Although I haven't added CI setup here yet, but I will do so in a separate PR; in theory it should be trivial.