### PR TITLE
add support for newline with Enter

### DIFF
--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -30,6 +30,7 @@ pub(super) fn run(
                     KeyCode::Up => app_state.ui_state.cursor_move_up(),
                     KeyCode::Backspace => app_state.ui_state.remove_previous_character(),
                     KeyCode::Delete => app_state.ui_state.remove_next_character(),
+                    KeyCode::Enter => app_state.ui_state.add_new_line(),
                     _ => {}
                 }
             }

--- a/src/app_state/navigation.rs
+++ b/src/app_state/navigation.rs
@@ -86,7 +86,7 @@ impl UIState {
         }
     }
 
-    fn get_line_len(&self, index: u16) -> u16 {
+    pub(super) fn get_line_len(&self, index: u16) -> u16 {
         // this will break if index is higher than 65535, which is not impossible
         // TODO: switch to `usize` everywhere, and only use `u16` for actual terminal
         match self.lines.get(index as usize) {

--- a/src/app_state/text_editing.rs
+++ b/src/app_state/text_editing.rs
@@ -64,6 +64,28 @@ impl UIState {
             }
         }
     }
+
+    pub fn add_new_line(&mut self) {
+        self.vertical_offset_target = 0;
+
+        let current_line_len = self.get_line_len(self.cursor_line - 1);
+
+        if self.cursor_column > current_line_len {
+            self.lines.insert(self.cursor_line as usize, vec![]);
+        } else {
+            match self.lines.get_mut((self.cursor_line - 1) as usize) {
+                Some(line) => {
+                    let new_line = line.split_off((self.cursor_column - 1) as usize);
+                    self.lines.insert(self.cursor_line as usize, new_line);
+                    self.cursor_line += 1;
+                    self.cursor_column = 1;
+                }
+                None => {
+                    // ???
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -130,5 +152,37 @@ mod tests {
 
         assert_eq!(String::from_iter(&ui_state.lines[0]), "world!");
         assert_eq!(ui_state.cursor_column, 1);
+    }
+
+    #[test]
+    fn adds_new_line_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        ui_state.cursor_move_right();
+        ui_state.cursor_move_right();
+        ui_state.cursor_move_right();
+
+        ui_state.add_new_line();
+
+        assert_eq!(ui_state.cursor_column, 1);
+        assert_eq!(ui_state.cursor_line, 2);
+
+        assert_eq!(String::from_iter(&ui_state.lines[0]), "Hel");
+        assert_eq!(String::from_iter(&ui_state.lines[1]), "lo world!");
+
+        ui_state.cursor_move_down();
+        ui_state.add_new_line();
+
+        assert_eq!(ui_state.cursor_column, 1);
+        assert_eq!(ui_state.cursor_line, 3);
+
+        assert_eq!(String::from_iter(&ui_state.lines[1]), "lo world!");
+        assert_eq!(String::from_iter(&ui_state.lines[4]), "Description");
     }
 }


### PR DESCRIPTION
## Description

Add support for new line with the Enter key.

## Reference

I think only proper handling of newlines with `del` and `backspace` are left, and after https://github.com/Bloomca/love/issues/14 will be done.