### PR TITLE
add navigation to start and end line

### DIFF
--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -24,7 +24,9 @@ pub(super) fn run(
                         return Ok(());
                     }
                     KeyCode::Char(character) => app_state.ui_state.insert_character(character),
+                    KeyCode::Home => app_state.ui_state.cursor_move_line_start(),
                     KeyCode::Left => app_state.ui_state.cursor_move_left(),
+                    KeyCode::End => app_state.ui_state.cursor_move_line_end(),
                     KeyCode::Right => app_state.ui_state.cursor_move_right(),
                     KeyCode::Down => app_state.ui_state.cursor_move_down(),
                     KeyCode::Up => app_state.ui_state.cursor_move_up(),

--- a/src/app_state/navigation.rs
+++ b/src/app_state/navigation.rs
@@ -71,6 +71,22 @@ impl UIState {
         }
     }
 
+    pub fn cursor_move_line_start(&mut self) {
+        if self.should_show_cursor {
+            self.vertical_offset_target = 0;
+            // TODO: implement going to the beginning of the line respecting white spaces
+            self.cursor_column = 1;
+        }
+    }
+
+    pub fn cursor_move_line_end(&mut self) {
+        if self.should_show_cursor {
+            self.vertical_offset_target = 0;
+            let line_len = self.get_line_len(self.cursor_line - 1);
+            self.cursor_column = line_len + 1;
+        }
+    }
+
     fn adjust_cursor_column_after_vertical_nav(&mut self) {
         // if it is not 0, it means we were pressing up/down before
         if self.vertical_offset_target == 0 {
@@ -259,5 +275,32 @@ mod tests {
 
         assert_eq!(ui_state.cursor_column, 3);
         assert_eq!(ui_state.cursor_line, 1);
+    }
+
+    #[test]
+    fn move_start_end_line_correctly() {
+        let lines = vec![
+            vec!['H', 'e', 'l', 'l', 'o'],
+            vec![],
+            vec!['D', 'e', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n'],
+        ];
+
+        let mut ui_state = UIState::new(5, lines);
+        ui_state.set_editor_offset(30, 0);
+
+        ui_state.cursor_move_line_end();
+        assert_eq!(ui_state.cursor_column, 6);
+        assert_eq!(ui_state.cursor_line, 1);
+
+        ui_state.cursor_move_down();
+        ui_state.cursor_move_down();
+
+        ui_state.cursor_move_line_start();
+        assert_eq!(ui_state.cursor_column, 1);
+        assert_eq!(ui_state.cursor_line, 3);
+
+        ui_state.cursor_move_line_end();
+        assert_eq!(ui_state.cursor_column, 12);
+        assert_eq!(ui_state.cursor_line, 3);
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Rect},
     style::{Style, Stylize},
     text::{Line, Span},
-    widgets::{Block, Paragraph, Wrap},
+    widgets::{Block, Paragraph},
 };
 
 use crate::app_state::AppState;
@@ -17,15 +17,14 @@ pub fn render_editor(frame: &mut Frame, area: Rect, app_state: &mut AppState) {
         .lines
         .iter()
         .enumerate()
-        .map(|(i, line)| generate_code_line(line.iter().collect::<String>(), i, lines_number))
+        .map(|(i, line)| generate_code_line(line.iter().collect::<String>(), i + 1, lines_number))
         .collect();
 
     let block = Block::bordered().title("Editor");
     let text_widget = Paragraph::new(text)
         .block(block)
         .style(Style::new().white().on_black())
-        .alignment(Alignment::Left)
-        .wrap(Wrap { trim: true });
+        .alignment(Alignment::Left);
 
     frame.render_widget(text_widget, area);
 }


### PR DESCRIPTION
## Description

Add an option to navigate to the beginning/end of the line. I originally wanted to include platform specific keys, but it turns out that these commands are often intercepted by the terminal, so I will try to stay with platform-independent keys.