### PR TITLE
refactor to use usize everywhere

### DIFF
--- a/src/app_state/app.rs
+++ b/src/app_state/app.rs
@@ -21,8 +21,7 @@ impl AppState {
         AppState {
             working_directory,
             file_tree: HashMap::new(),
-            // this is extremely safe, it needs to have 65535 digits to overflow
-            ui_state: UIState::new(lines_number.to_string().len() as u16, lines),
+            ui_state: UIState::new(lines_number.to_string().len(), lines),
         }
     }
 

--- a/src/app_state/navigation.rs
+++ b/src/app_state/navigation.rs
@@ -28,7 +28,7 @@ impl UIState {
 
             let line_len = self.get_line_len(self.cursor_line - 1);
             if self.cursor_column > line_len {
-                if self.cursor_line >= self.lines.len() as u16 {
+                if self.cursor_line >= self.lines.len() {
                     // we are on the last line, do nothing
                 } else {
                     // need to move to the next line
@@ -57,7 +57,7 @@ impl UIState {
 
     pub fn cursor_move_down(&mut self) {
         if self.should_show_cursor {
-            if self.cursor_line == self.lines.len() as u16 {
+            if self.cursor_line == self.lines.len() {
                 if self.vertical_offset_target == 0 {
                     self.vertical_offset_target = self.cursor_column;
                 }
@@ -102,11 +102,11 @@ impl UIState {
         }
     }
 
-    pub(super) fn get_line_len(&self, index: u16) -> u16 {
+    pub(super) fn get_line_len(&self, index: usize) -> usize {
         // this will break if index is higher than 65535, which is not impossible
         // TODO: switch to `usize` everywhere, and only use `u16` for actual terminal
-        match self.lines.get(index as usize) {
-            Some(line) => line.len() as u16,
+        match self.lines.get(index) {
+            Some(line) => line.len(),
             None => 0,
         }
     }

--- a/src/app_state/text_editing.rs
+++ b/src/app_state/text_editing.rs
@@ -4,11 +4,11 @@ impl UIState {
     pub fn insert_character(&mut self, character: char) {
         self.vertical_offset_target = 0;
 
-        let result = self.lines.get_mut((self.cursor_line - 1) as usize);
+        let result = self.lines.get_mut(self.cursor_line - 1);
 
         match result {
             Some(line) => {
-                let index = (self.cursor_column - 1) as usize;
+                let index = self.cursor_column - 1;
                 if index <= line.len() {
                     line.insert(index, character);
                     self.cursor_move_right();
@@ -23,7 +23,7 @@ impl UIState {
     pub fn remove_previous_character(&mut self) {
         self.vertical_offset_target = 0;
 
-        let index = (self.cursor_column - 1) as usize;
+        let index = self.cursor_column - 1;
 
         if self.cursor_column == 1 && self.cursor_line == 1 {
             // nothing to remove, we are already at the beginning
@@ -39,7 +39,7 @@ impl UIState {
             0
         };
 
-        if let Some(line) = self.lines.get_mut((self.cursor_line - 1) as usize) {
+        if let Some(line) = self.lines.get_mut(self.cursor_line - 1) {
             if index == 0 {
                 // we need to prepend current line to the previous one
                 // 1. call `let line = self.lines.remove(self.cursor_line - 1)`
@@ -49,10 +49,10 @@ impl UIState {
                 // similar idea with delete, but at the end of the line
 
                 if line.is_empty() {
-                    self.lines.remove((self.cursor_line - 1) as usize);
+                    self.lines.remove(self.cursor_line - 1);
                 } else {
-                    let mut current_line = self.lines.remove((self.cursor_line - 1) as usize);
-                    match self.lines.get_mut((self.cursor_line - 2) as usize) {
+                    let mut current_line = self.lines.remove(self.cursor_line - 1);
+                    match self.lines.get_mut(self.cursor_line - 2) {
                         Some(previous_line) => {
                             previous_line.append(&mut current_line);
                         }
@@ -75,21 +75,20 @@ impl UIState {
     pub fn remove_next_character(&mut self) {
         self.vertical_offset_target = 0;
 
-        let index = (self.cursor_column - 1) as usize;
+        let index = self.cursor_column - 1;
 
-        if let Some(line) = self.lines.get_mut((self.cursor_line - 1) as usize) {
+        if let Some(line) = self.lines.get_mut(self.cursor_line - 1) {
             let line_len = line.len();
             if index == line_len {
                 // we need to get the next line and append it to the current line
 
-                let is_last_line = self.lines.len() == self.cursor_line as usize;
+                let is_last_line = self.lines.len() == self.cursor_line;
                 if is_last_line {
                     // do nothing, we are at the end of the file
                 } else {
-                    let mut next_line = self.lines.remove(self.cursor_line as usize);
+                    let mut next_line = self.lines.remove(self.cursor_line);
 
-                    if let Some(current_line) = self.lines.get_mut((self.cursor_line - 1) as usize)
-                    {
+                    if let Some(current_line) = self.lines.get_mut(self.cursor_line - 1) {
                         current_line.append(&mut next_line);
                     }
                 }
@@ -105,12 +104,12 @@ impl UIState {
         let current_line_len = self.get_line_len(self.cursor_line - 1);
 
         if self.cursor_column > current_line_len {
-            self.lines.insert(self.cursor_line as usize, vec![]);
+            self.lines.insert(self.cursor_line, vec![]);
         } else {
-            match self.lines.get_mut((self.cursor_line - 1) as usize) {
+            match self.lines.get_mut(self.cursor_line - 1) {
                 Some(line) => {
-                    let new_line = line.split_off((self.cursor_column - 1) as usize);
-                    self.lines.insert(self.cursor_line as usize, new_line);
+                    let new_line = line.split_off(self.cursor_column - 1);
+                    self.lines.insert(self.cursor_line, new_line);
                     self.cursor_line += 1;
                     self.cursor_column = 1;
                 }

--- a/src/app_state/ui.rs
+++ b/src/app_state/ui.rs
@@ -36,11 +36,11 @@ impl FileTreeEntry {
 }
 
 pub struct UIState {
-    pub cursor_line: u16,
-    pub cursor_column: u16,
+    pub cursor_line: usize,
+    pub cursor_column: usize,
     pub lines: Vec<Vec<char>>,
-    editor_offset_x: u16,
-    editor_offset_y: u16,
+    editor_offset_x: usize,
+    editor_offset_y: usize,
 
     /// There are multiple widgets which can be focused, plus we might
     /// not even have a valid editor open (e.g. if all files are closed)
@@ -49,7 +49,7 @@ pub struct UIState {
     /// Each line is prefixed with the line number. To have a consistent
     /// prefix width, we take the highest number, take number of digits,
     /// and add `|` symbol and a space afterwards.
-    prefix_len: u16,
+    prefix_len: usize,
 
     /// When we navigate using up/down directions, we ideally want to stay
     /// on the same column vertically. It is not always possible, because
@@ -57,11 +57,11 @@ pub struct UIState {
     /// have enough! So in order to preserve that, we need to store the
     /// "target" column. It is invalidated the moment we navigate left or right,
     /// or insert a new character.
-    pub(super) vertical_offset_target: u16,
+    pub(super) vertical_offset_target: usize,
 }
 
 impl UIState {
-    pub fn new(prefix_len: u16, lines: Vec<Vec<char>>) -> Self {
+    pub fn new(prefix_len: usize, lines: Vec<Vec<char>>) -> Self {
         UIState {
             cursor_line: 1,
             cursor_column: 1,
@@ -75,7 +75,7 @@ impl UIState {
         }
     }
 
-    pub fn set_editor_offset(&mut self, x: u16, y: u16) {
+    pub fn set_editor_offset(&mut self, x: usize, y: usize) {
         // in theory, we only need to set this once. we might need to do again
         // if the file tree is resized, otherwise the offset should be steady.
         // for now, this should work
@@ -92,7 +92,7 @@ impl UIState {
             let y = self.cursor_line + self.editor_offset_y;
             let result = execute!(
                 io::stdout(),
-                MoveTo(x, y),
+                MoveTo(x as u16, y as u16),
                 SetCursorStyle::SteadyBlock,
                 Show
             );

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,7 +9,9 @@ use ratatui::{
 use crate::app_state::AppState;
 
 pub fn render_editor(frame: &mut Frame, area: Rect, app_state: &mut AppState) {
-    app_state.ui_state.set_editor_offset(area.x, area.y);
+    app_state
+        .ui_state
+        .set_editor_offset(area.x as usize, area.y as usize);
 
     let lines_number = app_state.ui_state.lines.len();
     let text: Vec<Line> = app_state


### PR DESCRIPTION
## Description

I originally went with `u16` because that's what `ratatui`/`crossterm` use internally, but it is PITA to carry it around, so the state will be in `usize`.