### PR TITLE
WIP expand tab into whitespaces

### DIFF
--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -33,6 +33,7 @@ pub(super) fn run(
                     KeyCode::Backspace => app_state.ui_state.remove_previous_character(),
                     KeyCode::Delete => app_state.ui_state.remove_next_character(),
                     KeyCode::Enter => app_state.ui_state.add_new_line(),
+                    KeyCode::Tab => app_state.ui_state.handle_tab_key(&app_state.config),
                     _ => {}
                 }
             }

--- a/src/app_state/app.rs
+++ b/src/app_state/app.rs
@@ -11,6 +11,21 @@ pub struct AppState {
     pub working_directory: PathBuf,
     pub file_tree: HashMap<PathBuf, Vec<FileTreeEntry>>,
     pub ui_state: UIState,
+    pub config: Config,
+}
+
+pub struct Config {
+    pub tabs_to_spaces: bool,
+    pub whitespaces_amount: usize,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config {
+            tabs_to_spaces: true,
+            whitespaces_amount: 4,
+        }
+    }
 }
 
 impl AppState {
@@ -22,6 +37,7 @@ impl AppState {
             working_directory,
             file_tree: HashMap::new(),
             ui_state: UIState::new(lines_number.to_string().len(), lines),
+            config: Config::new(),
         }
     }
 


### PR DESCRIPTION
## Description

Expand tab into whitespaces. I also introduce config, so it will be configurable in the future, but for now it will automatically expand to 4 spaces. I also don't make any exceptions, it is _always_ 4 spaces.

There are a few QoL things here, like adding a new line should respect current amount of whitespaces (not tabs though).

## Reference

Closes https://github.com/Bloomca/love/issues/49
