### PR TITLE
add clipboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +92,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags",
  "crossterm_winapi",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-crossterm = "0.29.0"
+crossterm = { version = "0.29.0", features = ["osc52"] }
 ratatui = "0.29.0"

--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -23,6 +23,9 @@ pub(super) fn run(
                         restore_terminal(terminal).expect("Could not shut down the app gracefully, terminal might not work properly");
                         return Ok(());
                     }
+                    KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::META) => {
+                        app_state.ui_state.handle_copy();
+                    }
                     KeyCode::Char(character) => app_state.ui_state.insert_character(character),
                     KeyCode::Home => app_state.ui_state.cursor_move_line_start(),
                     KeyCode::Left => app_state.ui_state.cursor_move_left(&key_event.modifiers),
@@ -38,6 +41,7 @@ pub(super) fn run(
                     _ => {}
                 }
             }
+            Event::Paste(data) => app_state.ui_state.handle_paste(data),
             _ => {}
         }
     }

--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -23,7 +23,7 @@ pub(super) fn run(
                         restore_terminal(terminal).expect("Could not shut down the app gracefully, terminal might not work properly");
                         return Ok(());
                     }
-                    KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::META) => {
+                    KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                         app_state.ui_state.handle_copy();
                     }
                     KeyCode::Char(character) => app_state.ui_state.insert_character(character),

--- a/src/app/terminal_setup.rs
+++ b/src/app/terminal_setup.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -10,7 +11,7 @@ pub(super) fn setup_terminal()
 -> Result<Terminal<CrosstermBackend<io::Stdout>>, Box<dyn std::error::Error>> {
     let mut stdout = io::stdout();
     enable_raw_mode()?;
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
     Ok(terminal)
@@ -22,7 +23,11 @@ pub(super) fn restore_terminal(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableBracketedPaste
+    )?;
     terminal.show_cursor()?;
     Ok(())
 }

--- a/src/app_state/editor.rs
+++ b/src/app_state/editor.rs
@@ -1,3 +1,4 @@
+mod clipboard;
 mod deleting_actions;
 mod insert_character_action;
 mod newline_action;

--- a/src/app_state/editor/clipboard.rs
+++ b/src/app_state/editor/clipboard.rs
@@ -1,0 +1,31 @@
+use crate::app_state::editor::UIState;
+
+impl UIState {
+    pub fn handle_paste(&mut self, data: String) {
+        self.vertical_offset_target = 0;
+
+        self.delete_selection();
+
+        let total_pasted_lines = data.lines().count();
+        let lines = data.lines().enumerate().collect::<Vec<_>>();
+
+        for (i, line) in lines {
+            if i == 0 {
+                // 1. get the current line
+                // 2. append the new line to it
+                // 3. if there is only one line, move cursor to it
+            } else {
+                // 1. get the previous line and calculate whitespaces
+                // 2. create a new line with those whitespaces and add new data
+                // 3. append that new line in the new index (self.cursor_line + i)
+                // 4. if that is the last line (i + 1 == total_pasted_lines), put cursor at the end
+            }
+        }
+    }
+
+    pub fn handle_copy(&self) {
+        // 1. read selection, if none do nothing
+        // 2. copy selection (join all strings with '\n' character)
+        // 3. Execute a crossterm command: https://docs.rs/crossterm/0.29.0/crossterm/clipboard/struct.CopyToClipboard.html
+    }
+}

--- a/src/app_state/editor/clipboard.rs
+++ b/src/app_state/editor/clipboard.rs
@@ -1,3 +1,7 @@
+use crossterm::clipboard::CopyToClipboard;
+use crossterm::execute;
+use std::io;
+
 use crate::app_state::editor::UIState;
 
 impl UIState {
@@ -6,19 +10,49 @@ impl UIState {
 
         self.delete_selection();
 
-        let total_pasted_lines = data.lines().count();
-        let lines = data.lines().enumerate().collect::<Vec<_>>();
+        // in my iTerm on macOS, newlines are replaced by `\r` by default
+        // to be safe, we normalize all possible line endings into '\n'
+        let normalized = data.replace("\r\n", "\n").replace("\r", "\n");
+        let total_pasted_lines = normalized.lines().count();
+        let lines: Vec<(usize, Vec<char>)> = normalized
+            .lines()
+            .map(|s| s.chars().collect())
+            .enumerate()
+            .collect();
 
-        for (i, line) in lines {
+        for (i, pasted_line) in lines {
             if i == 0 {
                 // 1. get the current line
                 // 2. append the new line to it
                 // 3. if there is only one line, move cursor to it
+                if let Some(line) = self.lines.get_mut(self.cursor_line - 1) {
+                    // we need to calculate index first, as we might change cursor next
+                    let index = self.cursor_column - 1;
+                    if total_pasted_lines == 1 {
+                        self.cursor_column += pasted_line.len();
+                    }
+                    line.splice(index..index, pasted_line);
+                }
             } else {
                 // 1. get the previous line and calculate whitespaces
                 // 2. create a new line with those whitespaces and add new data
                 // 3. append that new line in the new index (self.cursor_line + i)
                 // 4. if that is the last line (i + 1 == total_pasted_lines), put cursor at the end
+                if let Some(prev_line) = self.lines.get(self.cursor_line - 1 + i - 1) {
+                    let prev_line_whitespaces = Self::calculate_whitespace_num(prev_line);
+
+                    let prefixed_line: Vec<char> = vec![' '; prev_line_whitespaces]
+                        .into_iter()
+                        .chain(pasted_line)
+                        .collect();
+
+                    if total_pasted_lines == i + 1 {
+                        self.cursor_line += i - 1;
+                        self.cursor_column = prefixed_line.len();
+                    }
+
+                    self.lines.insert(self.cursor_line - 1 + i, prefixed_line);
+                }
             }
         }
     }
@@ -27,5 +61,74 @@ impl UIState {
         // 1. read selection, if none do nothing
         // 2. copy selection (join all strings with '\n' character)
         // 3. Execute a crossterm command: https://docs.rs/crossterm/0.29.0/crossterm/clipboard/struct.CopyToClipboard.html
+        if let Some(selection) = &self.selection {
+            let (start_line, start_column) = selection.start;
+            let (end_line, end_column) = selection.end;
+
+            if start_line == end_line {
+                if let Some(line) = self.lines.get(start_line - 1) {
+                    let start_index = start_column.min(end_column) - 1;
+                    let end_index = start_column.max(end_column);
+                    let text = line[start_index..end_index].iter().collect::<String>();
+                    Self::execute_terminal_copy(text);
+                }
+            } else {
+                let mut result = vec![];
+
+                let start_line_index = start_line.min(end_line);
+                let end_line_index = start_line.max(end_line);
+                let first_line_column = if start_line < end_line {
+                    start_column
+                } else {
+                    end_column
+                };
+                let last_line_column = if start_line > end_line {
+                    start_column
+                } else {
+                    end_column
+                };
+                for i in start_line_index..=end_line_index {
+                    if i != start_line {
+                        result.push('\n');
+                    }
+
+                    if i == start_line_index {
+                        if let Some(line) = self.lines.get(i - 1) {
+                            let start_index = first_line_column - 1;
+                            result.extend_from_slice(&line[start_index..]);
+                        }
+                    }
+
+                    if i == end_line_index {
+                        if let Some(line) = self.lines.get(i - 1) {
+                            let end_index = last_line_column - 1;
+                            result.extend_from_slice(&line[..end_index]);
+                        }
+                    }
+
+                    if i != start_line_index && i != end_line_index {
+                        if let Some(line) = self.lines.get(i - 1) {
+                            result.extend_from_slice(line);
+                        }
+                    }
+                }
+
+                let text = result.iter().collect::<String>();
+                Self::execute_terminal_copy(text);
+            }
+        } else {
+            // do nothing
+        }
+    }
+
+    fn execute_terminal_copy(data: String) {
+        match execute!(io::stdout(), CopyToClipboard::to_clipboard_from(data)) {
+            Ok(_) => {
+                // pass
+            }
+            Err(_) => {
+                // pass
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Add clipboard support.

Originally I thought I need to use something like [arboard](https://crates.io/crates/arboard), but it seems to be not necessary -- `crossterm` provides basic text functionality, which should be enough at least to get started.

## Reference

Closes https://github.com/Bloomca/love/issues/51