### PR TITLE
support newlines in undo/redo

### DIFF
--- a/src/app/run_event_loop.rs
+++ b/src/app/run_event_loop.rs
@@ -57,7 +57,7 @@ pub(super) fn run(
                     KeyCode::Delete => app_state
                         .ui_state
                         .remove_next_character(&mut app_state.undo_redo),
-                    KeyCode::Enter => app_state.ui_state.add_new_line(),
+                    KeyCode::Enter => app_state.ui_state.add_new_line(&mut app_state.undo_redo),
                     KeyCode::BackTab => app_state.ui_state.handle_backtab_key(&app_state.config),
                     KeyCode::Tab => app_state
                         .ui_state

--- a/src/app_state/editor/selection_actions.rs
+++ b/src/app_state/editor/selection_actions.rs
@@ -254,7 +254,7 @@ mod tests {
         ui_state.cursor_move_left(&KeyModifiers::SHIFT);
         ui_state.cursor_move_left(&KeyModifiers::SHIFT);
 
-        ui_state.add_new_line();
+        ui_state.add_new_line(&mut undo_redo);
 
         assert_eq!(ui_state.cursor_column, 1);
         assert_eq!(ui_state.cursor_line, 3);
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(String::from_iter(&ui_state.lines[0]), "H world!");
 
         ui_state.cursor_move_line_end(&KeyModifiers::NONE);
-        ui_state.add_new_line();
+        ui_state.add_new_line(&mut undo_redo);
 
         ui_state.insert_character('S', &mut undo_redo);
         ui_state.insert_character('o', &mut undo_redo);


### PR DESCRIPTION
## Description

Add support for newlines when adding new characters to the undo/redo system. I also refactored it a bit so we don't replicate this logic for deleting/inserting ranges.

## References

Closes https://github.com/Bloomca/love/issues/73