### PR TITLE
add undo redo selection support when deleting

### DIFF
--- a/src/app_state/editor/deleting_actions.rs
+++ b/src/app_state/editor/deleting_actions.rs
@@ -7,7 +7,12 @@ impl UIState {
         self.vertical_offset_target = 0;
 
         // if we successfully deleted the selection, we don't need to do anything else
-        if self.delete_selection().is_some() {
+        if let Some(removed_selection) = self.delete_selection() {
+            undo_redo.add_undo_action(UndoAction::RemoveSelection(
+                removed_selection,
+                (self.cursor_line, self.cursor_column),
+                RemoveBufferType::Backspace,
+            ));
             return;
         }
 
@@ -84,7 +89,12 @@ impl UIState {
         self.vertical_offset_target = 0;
 
         // if we successfully deleted the selection, we don't need to do anything else
-        if self.delete_selection().is_some() {
+        if let Some(removed_selection) = self.delete_selection() {
+            undo_redo.add_undo_action(UndoAction::RemoveSelection(
+                removed_selection,
+                (self.cursor_line, self.cursor_column),
+                RemoveBufferType::Delete,
+            ));
             return;
         }
 


### PR DESCRIPTION
## Description

Similar to https://github.com/Bloomca/love/pull/78 and https://github.com/Bloomca/love/pull/79, add undo redo support when deleting characters.

## Reference

Closes https://github.com/Bloomca/love/issues/75